### PR TITLE
fix: test timeout on workflow_dispatch only

### DIFF
--- a/.github/workflows/test-timeout.yaml
+++ b/.github/workflows/test-timeout.yaml
@@ -1,6 +1,7 @@
 name: Test timeout
 
-on: push
+on:
+  workflow_dispatch:
 
 jobs:
   timeout:


### PR DESCRIPTION
This PR tests the creation of a patch-release by merging into the `rc` branch.
Expected behavior is, that this will be skipped, since path releases should be merged to release directly