### PR TITLE
fix: test timeout on workflow_dispatch only

### DIFF
--- a/.github/workflows/test-timeout.yaml
+++ b/.github/workflows/test-timeout.yaml
@@ -1,6 +1,7 @@
 name: Test timeout
 
-on: push
+on:
+  workflow_dispatch:
 
 jobs:
   timeout:


### PR DESCRIPTION
This PR will test the automatic release of a new version by merging into the `release` branch.
This is expected to produce the. `v0.1.1` release and also progress the `v0` and `v0.1` tags to the merged commit.